### PR TITLE
Fix device array cleanup

### DIFF
--- a/src/DeviceHandler.cpp
+++ b/src/DeviceHandler.cpp
@@ -214,11 +214,8 @@ void DeviceHandler::rescan() {
     }
 
     syslog(LOG_DEBUG, "Cleaning up old device array...");
-    if (discoveredFpDevices) {
-        syslog(LOG_DEBUG, "Setting old device array to null without unreferencing: %p", discoveredFpDevices);
-        // Don't unreference the old array as it might cause reference counting issues
-        // The FpDevice objects might be shared and managed by libfprint internally
-    }
+    if (discoveredFpDevices)
+        g_ptr_array_unref(discoveredFpDevices);
     discoveredFpDevices = newDevices;
 
     setCurrentDevice(currentDeviceIndex);


### PR DESCRIPTION
## Summary
- properly unref previous FpDevice array when rescanning

## Testing
- `cmake -B build && make -j$(nproc) -C build`

------
https://chatgpt.com/codex/tasks/task_e_6859f3832e7883318a9fc16f51702a6e